### PR TITLE
Use async for get_hints

### DIFF
--- a/smart_word_hints_api/app/main.py
+++ b/smart_word_hints_api/app/main.py
@@ -60,7 +60,7 @@ en_to_en_hints_provider = EnglishToEnglishHintsProvider()
 
 @app.post(f"/api/v{MAJOR_VERSION}/get_hints")
 @app.post("/api/latest/get_hints")
-def get_hints(request_body: WordHintsRequest):
+async def get_hints(request_body: WordHintsRequest):
     hints = en_to_en_hints_provider.get_hints(
         request_body.text,
         request_body.options.avoid_repetitions,  # type: ignore


### PR DESCRIPTION
Without it, the get_hints function was working in a thread pool dedicated for non-async def endpoints. This was casuing issues as NLTK (and wordnet in particular) don't work well in a multithreading environment.